### PR TITLE
Only define service-list once and reuse for decorator/server mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,9 @@ Select Operation: create_deployment
 You will still need to add the mock into "__init__.py"
 ```
 
+### URL Indexing
+In order to speed up the performance of MotoServer, all AWS URL's that need intercepting are indexed.  
+When adding/replacing any URLs in `{service}/urls.py`, please run `python scripts/update_backend_index.py` to update this index.
 
 ## Maintainers
 

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -3,11 +3,15 @@ from __future__ import unicode_literals
 import importlib
 
 
-def lazy_load(module_name, element):
+def lazy_load(module_name, element, boto3_name=None, backend=None):
     def f(*args, **kwargs):
         module = importlib.import_module(module_name, "moto")
         return getattr(module, element)(*args, **kwargs)
 
+    setattr(f, "name", module_name.replace(".", ""))
+    setattr(f, "element", element)
+    setattr(f, "boto3_name", boto3_name or f.name)
+    setattr(f, "backend", backend or f"{f.name}_backends")
     return f
 
 
@@ -20,7 +24,9 @@ mock_applicationautoscaling = lazy_load(
 )
 mock_autoscaling = lazy_load(".autoscaling", "mock_autoscaling")
 mock_autoscaling_deprecated = lazy_load(".autoscaling", "mock_autoscaling_deprecated")
-mock_lambda = lazy_load(".awslambda", "mock_lambda")
+mock_lambda = lazy_load(
+    ".awslambda", "mock_lambda", boto3_name="lambda", backend="lambda_backends"
+)
 mock_lambda_deprecated = lazy_load(".awslambda", "mock_lambda_deprecated")
 mock_batch = lazy_load(".batch", "mock_batch")
 mock_batch = lazy_load(".batch", "mock_batch")
@@ -32,11 +38,13 @@ mock_cloudwatch = lazy_load(".cloudwatch", "mock_cloudwatch")
 mock_cloudwatch_deprecated = lazy_load(".cloudwatch", "mock_cloudwatch_deprecated")
 mock_codecommit = lazy_load(".codecommit", "mock_codecommit")
 mock_codepipeline = lazy_load(".codepipeline", "mock_codepipeline")
-mock_cognitoidentity = lazy_load(".cognitoidentity", "mock_cognitoidentity")
+mock_cognitoidentity = lazy_load(
+    ".cognitoidentity", "mock_cognitoidentity", boto3_name="cognito-identity"
+)
 mock_cognitoidentity_deprecated = lazy_load(
     ".cognitoidentity", "mock_cognitoidentity_deprecated"
 )
-mock_cognitoidp = lazy_load(".cognitoidp", "mock_cognitoidp")
+mock_cognitoidp = lazy_load(".cognitoidp", "mock_cognitoidp", boto3_name="cognito-idp")
 mock_cognitoidp_deprecated = lazy_load(".cognitoidp", "mock_cognitoidp_deprecated")
 mock_config = lazy_load(".config", "mock_config")
 mock_datapipeline = lazy_load(".datapipeline", "mock_datapipeline")
@@ -47,10 +55,12 @@ mock_datasync = lazy_load(".datasync", "mock_datasync")
 mock_dms = lazy_load(".dms", "mock_dms")
 mock_dynamodb = lazy_load(".dynamodb", "mock_dynamodb")
 mock_dynamodb_deprecated = lazy_load(".dynamodb", "mock_dynamodb_deprecated")
-mock_dynamodb2 = lazy_load(".dynamodb2", "mock_dynamodb2")
+mock_dynamodb2 = lazy_load(".dynamodb2", "mock_dynamodb2", backend="dynamodb_backends2")
 mock_dynamodb2_deprecated = lazy_load(".dynamodb2", "mock_dynamodb2_deprecated")
 mock_dynamodbstreams = lazy_load(".dynamodbstreams", "mock_dynamodbstreams")
-mock_elasticbeanstalk = lazy_load(".elasticbeanstalk", "mock_elasticbeanstalk")
+mock_elasticbeanstalk = lazy_load(
+    ".elasticbeanstalk", "mock_elasticbeanstalk", backend="eb_backends"
+)
 mock_ec2 = lazy_load(".ec2", "mock_ec2")
 mock_ec2_deprecated = lazy_load(".ec2", "mock_ec2_deprecated")
 mock_ec2instanceconnect = lazy_load(".ec2instanceconnect", "mock_ec2instanceconnect")
@@ -71,7 +81,7 @@ mock_glue = lazy_load(".glue", "mock_glue")
 mock_iam = lazy_load(".iam", "mock_iam")
 mock_iam_deprecated = lazy_load(".iam", "mock_iam_deprecated")
 mock_iot = lazy_load(".iot", "mock_iot")
-mock_iotdata = lazy_load(".iotdata", "mock_iotdata")
+mock_iotdata = lazy_load(".iotdata", "mock_iotdata", boto3_name="iot-data")
 mock_kinesis = lazy_load(".kinesis", "mock_kinesis")
 mock_kinesis_deprecated = lazy_load(".kinesis", "mock_kinesis_deprecated")
 mock_kms = lazy_load(".kms", "mock_kms")
@@ -86,11 +96,13 @@ mock_polly = lazy_load(".polly", "mock_polly")
 mock_ram = lazy_load(".ram", "mock_ram")
 mock_rds = lazy_load(".rds", "mock_rds")
 mock_rds_deprecated = lazy_load(".rds", "mock_rds_deprecated")
-mock_rds2 = lazy_load(".rds2", "mock_rds2")
+mock_rds2 = lazy_load(".rds2", "mock_rds2", boto3_name="rds")
 mock_rds2_deprecated = lazy_load(".rds2", "mock_rds2_deprecated")
 mock_redshift = lazy_load(".redshift", "mock_redshift")
 mock_redshift_deprecated = lazy_load(".redshift", "mock_redshift_deprecated")
-mock_resourcegroups = lazy_load(".resourcegroups", "mock_resourcegroups")
+mock_resourcegroups = lazy_load(
+    ".resourcegroups", "mock_resourcegroups", boto3_name="resource-groups"
+)
 mock_resourcegroupstaggingapi = lazy_load(
     ".resourcegroupstaggingapi", "mock_resourcegroupstaggingapi"
 )
@@ -107,7 +119,9 @@ mock_sns_deprecated = lazy_load(".sns", "mock_sns_deprecated")
 mock_sqs = lazy_load(".sqs", "mock_sqs")
 mock_sqs_deprecated = lazy_load(".sqs", "mock_sqs_deprecated")
 mock_ssm = lazy_load(".ssm", "mock_ssm")
-mock_stepfunctions = lazy_load(".stepfunctions", "mock_stepfunctions")
+mock_stepfunctions = lazy_load(
+    ".stepfunctions", "mock_stepfunctions", backend="stepfunction_backends"
+)
 mock_sts = lazy_load(".sts", "mock_sts")
 mock_sts_deprecated = lazy_load(".sts", "mock_sts_deprecated")
 mock_swf = lazy_load(".swf", "mock_swf")
@@ -118,7 +132,9 @@ mock_xray = lazy_load(".xray", "mock_xray")
 mock_xray_client = lazy_load(".xray", "mock_xray_client")
 mock_kinesisvideo = lazy_load(".kinesisvideo", "mock_kinesisvideo")
 mock_kinesisvideoarchivedmedia = lazy_load(
-    ".kinesisvideoarchivedmedia", "mock_kinesisvideoarchivedmedia"
+    ".kinesisvideoarchivedmedia",
+    "mock_kinesisvideoarchivedmedia",
+    boto3_name="kinesis-video-archived-media",
 )
 mock_medialive = lazy_load(".medialive", "mock_medialive")
 mock_support = lazy_load(".support", "mock_support")
@@ -126,7 +142,9 @@ mock_mediaconnect = lazy_load(".mediaconnect", "mock_mediaconnect")
 mock_mediapackage = lazy_load(".mediapackage", "mock_mediapackage")
 mock_mediastore = lazy_load(".mediastore", "mock_mediastore")
 mock_eks = lazy_load(".eks", "mock_eks")
-mock_mediastoredata = lazy_load(".mediastoredata", "mock_mediastoredata")
+mock_mediastoredata = lazy_load(
+    ".mediastoredata", "mock_mediastoredata", boto3_name="mediastore-data"
+)
 mock_efs = lazy_load(".efs", "mock_efs")
 mock_wafv2 = lazy_load(".wafv2", "mock_wafv2")
 

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -1,92 +1,18 @@
 from __future__ import unicode_literals
 
 import importlib
+import moto
 
-BACKENDS = {
-    "acm": ("acm", "acm_backends"),
-    "apigateway": ("apigateway", "apigateway_backends"),
-    "athena": ("athena", "athena_backends"),
-    "applicationautoscaling": (
-        "applicationautoscaling",
-        "applicationautoscaling_backends",
-    ),
-    "autoscaling": ("autoscaling", "autoscaling_backends"),
-    "batch": ("batch", "batch_backends"),
-    "cloudformation": ("cloudformation", "cloudformation_backends"),
-    "cloudwatch": ("cloudwatch", "cloudwatch_backends"),
-    "codecommit": ("codecommit", "codecommit_backends"),
-    "codepipeline": ("codepipeline", "codepipeline_backends"),
-    "cognito-identity": ("cognitoidentity", "cognitoidentity_backends"),
-    "cognito-idp": ("cognitoidp", "cognitoidp_backends"),
-    "config": ("config", "config_backends"),
-    "datapipeline": ("datapipeline", "datapipeline_backends"),
-    "datasync": ("datasync", "datasync_backends"),
-    "dms": ("dms", "dms_backends"),
-    "dynamodb": ("dynamodb", "dynamodb_backends"),
-    "dynamodb2": ("dynamodb2", "dynamodb_backends2"),
-    "dynamodbstreams": ("dynamodbstreams", "dynamodbstreams_backends"),
-    "ec2": ("ec2", "ec2_backends"),
-    "ec2instanceconnect": ("ec2instanceconnect", "ec2instanceconnect_backends"),
-    "ecr": ("ecr", "ecr_backends"),
-    "ecs": ("ecs", "ecs_backends"),
-    "elasticbeanstalk": ("elasticbeanstalk", "eb_backends"),
-    "elb": ("elb", "elb_backends"),
-    "elbv2": ("elbv2", "elbv2_backends"),
-    "emr": ("emr", "emr_backends"),
-    "events": ("events", "events_backends"),
-    "glacier": ("glacier", "glacier_backends"),
-    "glue": ("glue", "glue_backends"),
-    "iam": ("iam", "iam_backends"),
-    "instance_metadata": ("instance_metadata", "instance_metadata_backends"),
-    "iot": ("iot", "iot_backends"),
-    "iot-data": ("iotdata", "iotdata_backends"),
-    "kinesis": ("kinesis", "kinesis_backends"),
-    "kms": ("kms", "kms_backends"),
-    "lambda": ("awslambda", "lambda_backends"),
-    "logs": ("logs", "logs_backends"),
-    "managedblockchain": ("managedblockchain", "managedblockchain_backends"),
-    "moto_api": ("core", "moto_api_backends"),
-    "opsworks": ("opsworks", "opsworks_backends"),
-    "organizations": ("organizations", "organizations_backends"),
-    "polly": ("polly", "polly_backends"),
-    "ram": ("ram", "ram_backends"),
-    "rds": ("rds2", "rds2_backends"),
-    "redshift": ("redshift", "redshift_backends"),
-    "resource-groups": ("resourcegroups", "resourcegroups_backends"),
-    "resourcegroupstaggingapi": (
-        "resourcegroupstaggingapi",
-        "resourcegroupstaggingapi_backends",
-    ),
-    "route53": ("route53", "route53_backends"),
-    "s3": ("s3", "s3_backends"),
-    "s3bucket_path": ("s3", "s3_backends"),
-    "sagemaker": ("sagemaker", "sagemaker_backends"),
-    "secretsmanager": ("secretsmanager", "secretsmanager_backends"),
-    "ses": ("ses", "ses_backends"),
-    "sns": ("sns", "sns_backends"),
-    "sqs": ("sqs", "sqs_backends"),
-    "ssm": ("ssm", "ssm_backends"),
-    "stepfunctions": ("stepfunctions", "stepfunction_backends"),
-    "sts": ("sts", "sts_backends"),
-    "swf": ("swf", "swf_backends"),
-    "transcribe": ("transcribe", "transcribe_backends"),
-    "xray": ("xray", "xray_backends"),
-    "kinesisvideo": ("kinesisvideo", "kinesisvideo_backends"),
-    "medialive": ("medialive", "medialive_backends"),
-    "kinesis-video-archived-media": (
-        "kinesisvideoarchivedmedia",
-        "kinesisvideoarchivedmedia_backends",
-    ),
-    "forecast": ("forecast", "forecast_backends"),
-    "support": ("support", "support_backends"),
-    "mediaconnect": ("mediaconnect", "mediaconnect_backends"),
-    "mediapackage": ("mediapackage", "mediapackage_backends"),
-    "mediastore": ("mediastore", "mediastore_backends"),
-    "mediastore-data": ("mediastoredata", "mediastoredata_backends"),
-    "eks": ("eks", "eks_backends"),
-    "efs": ("efs", "efs_backends"),
-    "wafv2": ("wafv2", "wafv2_backends"),
-}
+decorators = [
+    d
+    for d in dir(moto)
+    if d.startswith("mock_") and not d.endswith("_deprecated") and not d == "mock_all"
+]
+decorator_functions = [getattr(moto, f) for f in decorators]
+BACKENDS = {f.boto3_name: (f.name, f.backend) for f in decorator_functions}
+BACKENDS["moto_api"] = ("core", "moto_api_backends")
+BACKENDS["instance_metadata"] = ("instance_metadata", "instance_metadata_backends")
+BACKENDS["s3bucket_path"] = ("s3", "s3_backends")
 
 
 def _import_backend(module_name, backends_name):
@@ -107,12 +33,6 @@ def named_backends():
 def get_backend(name):
     module_name, backends_name = BACKENDS[name]
     return _import_backend(module_name, backends_name)
-
-
-def search_backend(predicate):
-    for name, backend in named_backends():
-        if predicate(backend):
-            return name
 
 
 def get_model(name, region_name):

--- a/moto/server.py
+++ b/moto/server.py
@@ -68,6 +68,11 @@ class DomainDispatcherApplication(object):
             if pattern.match("http://%s" % host):
                 return backend
 
+        print(
+            "Unable to find appropriate URL for {}."
+            "Remember to add the URL to urls.py, and run script/update_backend_index.py to index it."
+        )
+
     def infer_service_region_host(self, environ):
         auth = environ.get("HTTP_AUTHORIZATION")
         target = environ.get("HTTP_X_AMZ_TARGET")

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -122,39 +122,13 @@ def append_mock_to_init_py(service):
     filtered_lines = [_ for _ in lines if re.match("^mock_.*lazy_load(.*)$", _)]
     last_import_line_index = lines.index(filtered_lines[-1])
 
-    new_line = 'mock_{} = lazy_load(".{}", "mock_{}")'.format(
+    new_line = 'mock_{} = lazy_load(".{}", "mock_{}", boto3_name="{}")'.format(
         get_escaped_service(service),
         get_escaped_service(service),
         get_escaped_service(service),
+        service
     )
     lines.insert(last_import_line_index + 1, new_line)
-
-    body = "\n".join(lines) + "\n"
-    with open(path, "w") as f:
-        f.write(body)
-
-
-def append_mock_dict_to_backends_py(service):
-    path = os.path.join(os.path.dirname(__file__), "..", "moto", "backends.py")
-    with open(path) as f:
-        lines = [_.replace("\n", "") for _ in f.readlines()]
-
-    if any(
-        _
-        for _ in lines
-        if re.match('.*"{}": {}_backends.*'.format(service, service), _)
-    ):
-        return
-    filtered_lines = [_ for _ in lines if re.match('.*".*":.*_backends.*', _)]
-    last_elem_line_index = lines.index(filtered_lines[-1])
-
-    new_line = '    "{}": ("{}", "{}_backends"),'.format(
-        service, get_escaped_service(service), get_escaped_service(service)
-    )
-    prev_line = lines[last_elem_line_index]
-    if not prev_line.endswith("{") and not prev_line.endswith(","):
-        lines[last_elem_line_index] += ","
-    lines.insert(last_elem_line_index + 1, new_line)
 
     body = "\n".join(lines) + "\n"
     with open(path, "w") as f:
@@ -208,7 +182,6 @@ def initialize_service(service, operation, api_protocol):
 
     # append mock to init files
     append_mock_to_init_py(service)
-    append_mock_dict_to_backends_py(service)
 
 
 def to_upper_camel_case(s):


### PR DESCRIPTION

> @bblommers do you see this as a viable solution, or do you have concerns? i understand it's at the guts of the framework, and i'm happy to discuss alternatives :-)


Sorry about the radio silence @thrau - I've just been mulling it over. It's a reasonable solution, and does pave the way for even further performance improvements down the line. 

I've started this PR originally to try and call `update_backend_index.py` during `python setup.py install`, but didn't manage to make it work. So as an alternative improvement, I've added some documentation, removed some unnecessary methods and removed the hardcoded `BACKENDS`-dictionary, to at least make it as DRY as possible.

As far as I can tell this doesn't impact your solution - i.e., startup is still immediate, and the module is only loaded on the first HTTP request. Are you able to verify this?